### PR TITLE
chore: Drop references to Shaka Player Embedded

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 
 ## Repositories
 
-The Shaka Project covers four main streaming media products, plus several
+The Shaka Project covers three main streaming media products, plus several
 related tools:
 
  - [Shaka Player](https://github.com/shaka-project/shaka-player)
  - [Shaka Packager](https://github.com/shaka-project/shaka-packager)
- - [Shaka Player Embedded](https://github.com/shaka-project/shaka-player-embedded)
  - [Shaka Streamer](https://github.com/shaka-project/shaka-streamer)
 
 See the [full list of our repositories on GitHub](https://github.com/orgs/shaka-project/repositories).

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -18,7 +18,6 @@ Our Triage Party instance provides views that are scoped to specific groups of
 projects:
  - [Shaka Player](https://triage-party.shakalab.rocks/s/Player)
  - [Shaka Packager](https://triage-party.shakalab.rocks/s/Packager)
- - [Shaka Player Embedded](https://triage-party.shakalab.rocks/s/Embedded)
  - [Shaka Streamer](https://triage-party.shakalab.rocks/s/Streamer)
  - [Infrastructure projects](https://triage-party.shakalab.rocks/s/Infra)
  - [EME Logger](https://triage-party.shakalab.rocks/s/Logger)
@@ -132,7 +131,6 @@ as any NPM, PyPi, or other releases necessary.
 > :information_source: **NOTE**: The following repositories have not yet
 > adopted the release automation described here:
 > - [Shaka Packager](https://github.com/shaka-project/shaka-packager)
-> - [Shaka Player Embedded](https://github.com/shaka-project/shaka-player-embedded)
 > - [Shaka Streamer](https://github.com/shaka-project/shaka-streamer)
 </details>
 


### PR DESCRIPTION
The project is now deprecated and will be archived at the end of the quarter.